### PR TITLE
Faster entropy and random sequence comparison.

### DIFF
--- a/shannon-entropy.py
+++ b/shannon-entropy.py
@@ -6,6 +6,7 @@ import collections
 from collections import Counter
 
 seq = "tatgagtcatcacataaaagctaatgtagtaaagcatccataccaattgatttaaaattaaactaatccgttgataaaacaaaaaatcaagagccttgagtcactccagactgagaagattgactcaagaacaaattttatttttattttattagaggctccattggaaaaataagacctaaacattaatcgagaagtgatgggaacgatggaacctgtaaatacataagatgttactgaaaacaaatcttaatgatttattgggaggatagcgaaatgaaccagaagacaatcgatttattttattatgagagatcatgggttacctctacaaataaaataactattgaaagactaaatatgcaagaggaaatattcgcccgcgaagattttttttatattctttttgattgctaaatttgatcaatctgatatcctaattcgaatatataaaaaaatttgttacaaccttataacaaataacaaaaacactattattgaaaatcaaaaaataaaatagaaaaaattctctataattataattaatgtgtataactagaataattttttctatttctatctataactattagatctagaactagtagaactctaaaatagaatatagattctaatttatatatattagatacaaatttatattctactaatattctattctacctaatatcctattctaataatctaagattctaatactaataaatagatcgaataagtaagaaataaattaaaataaatagatttaactaaattaagtgaaatctcaaagaatacgatgatttaatatattattttattcgtaaaagacatggatatttttttttaatcatttcattcgcgaggagctggatgagaagaaattctcatgtccggttctgtagtagagatggaattgagaaataaccatcaactataaccccaaaagaacccgattccgtaaacaacatagaggaagaatgaaaggaatagcttttcgaggaaatcgtatttgttttggaagatatgctcttcaagcacttgaatccgcttggattacatctaga"
+randomseq = "".join(np.random.choice(["a","t","c","g"], size=len(seq)))
 #from Euphorbia iharanae genome, arbitrary choice
 
 seq_list = list(seq)
@@ -15,13 +16,31 @@ def Shannon_entropy_func(sequence, blocksize):
     N=len(sequence) -blocksize +1
     Block=[sequence[i:i +blocksize] for i in range(N)]
     entropy = sum([math.log(float(N)/Block.count(b)) for b in Block])/N
-    print(entropy)
+    return (entropy)
 
-# maybe this should be return(entropy)
+def Shannon_entropy_dmp(sequence, blocksize):
+    N = len(sequence) - blocksize + 1
+    counter = Counter([sequence[i:i+blocksize] for i in range(N)])
+    counts = np.array(list(counter.values()))
 
-for blocksize in range(500):
-    Shannon_entropy_func(seq_list, blocksize)
-    blocksize += 1
+    # The following normalizations are to match Shannon_entropy_func
+    # and are not necessarily correct
+    normalization = -1/N
+    normalization_add = np.log(N)
+
+    entropy = np.sum(counts * np.log(counts)) * normalization + normalization_add
+    return entropy
+
+
+for blocksize in range(1, 20):
+    # Using seq instead of seq_list lets you treat the subsequences as
+    # strings instead of lists, which is faster
+    slowvalue = Shannon_entropy_func(seq, blocksize)
+    dmpvalue = Shannon_entropy_dmp(seq, blocksize)
+    randvalue = Shannon_entropy_dmp(randomseq, blocksize)
+    print(f"{blocksize:10d} {slowvalue:8.3f}  {dmpvalue:8.3f}     {randvalue:8.3f}")
+
+    #    blocksize += 1
 
 #goes through every block length 1 - 500 (somewhat arbitrary max
 #limit, need to look into where is the proper place to stop) and


### PR DESCRIPTION
The block size should probably be around the base-4 log of the total length.  This for a random sequence would give about 1 copy on average of each possible substring.  Therefore if you have a few strings that have many more than one copy, the sequence is not random.  You can also see how many copies of strings you get that are several times that.


You have:
```
N=len(sequence) -blocksize +1
Block=[sequence[i:i +blocksize] for i in range(N)]
entropy = sum([math.log(float(N)/Block.count(b)) for b in Block])/N
```

This last line is a very inefficient way of multiplying the number of copies by the log of the number of copies.
For each of N entries in block, you are searching through all N entries to find a match, which means that the time it takes will go as N^2
This doesn’t matter too much when you only have a thousand bases, but when you get to a billion in full genome, it takes a billion times as long as it would for a linear search

```
print(entropy)
```

As your comment says, returning the value and having the calling function print it is better

```
blocksize += 1
```

That is unnecessary because `blocksize in range…` sets blocksize to a new value each time through the loop.
(Also, you want to start with a blocksize of 1, not zero.)


